### PR TITLE
Explicitly load the config file. This makes sure a logical error is given when is config-file is missing.

### DIFF
--- a/libraries/Session.php
+++ b/libraries/Session.php
@@ -50,6 +50,7 @@ class Session
      */
      private function initialize($config)
      {
+        $this->ci->load->config('session');
         $config = array_merge
         (
             array


### PR DESCRIPTION
When the session.php config file is missing, there is no direct error. However the application gives a general error. Explicitly loading the config file makes sure the developer knows what going wrong.
