### PR TITLE
change sess_create

### DIFF
--- a/libraries/Session.php
+++ b/libraries/Session.php
@@ -156,6 +156,9 @@ class Session
      */
     public function sess_create()
     {
+        // Send a new session id to client
+        session_regenerate_id();
+        
         $_SESSION[$this->sess_namespace] = array(
             'session_id' => md5(microtime()),
             'last_activity' => time()


### PR DESCRIPTION
When the session is destroyed and recreated,  the client can't retrieve the new session id instantly, after redirect to other pages, a fresh new session will be created ( since the client does not have session id at that time).
'session_regenerate_id()' ensure the client get the new session id in time.
